### PR TITLE
Type as `Array<String>` forcing to base type that Portion and Stringl…

### DIFF
--- a/src/tink/url/Path.hx
+++ b/src/tink/url/Path.hx
@@ -5,7 +5,7 @@ using StringTools;
 
 abstract Path(String) to String {
   
-  public function parts()
+  public function parts():Array<String>
     return [for (p in this.split('/')) if (p != '') new Portion(p)];//TODO: consider using a cache
   
   public var absolute(get, never):Bool;


### PR DESCRIPTION
…y accept.

Goes with https://github.com/haxetink/tink_web/pull/14.