### PR TITLE
Add PortionArray

### DIFF
--- a/src/tink/url/Path.hx
+++ b/src/tink/url/Path.hx
@@ -5,7 +5,7 @@ using StringTools;
 
 abstract Path(String) to String {
   
-  public function parts()
+  public function parts():PortionArray
     return [for (p in this.split('/')) if (p != '') new Portion(p)];//TODO: consider using a cache
   
   public var absolute(get, never):Bool;

--- a/src/tink/url/PortionArray.hx
+++ b/src/tink/url/PortionArray.hx
@@ -1,0 +1,8 @@
+package tink.url;
+
+@:forward
+abstract PortionArray(Array<Portion>) from Array<Portion> to Array<Portion> {
+	@:to
+	public function toStringArray()
+		return [for(p in this) p.toString()];
+}


### PR DESCRIPTION
Currently we can't do:

```haxe
switch path.parts() {
  case []:
  case ['projects', id]:
  default:
}
```

because the compiler cannot pattern-match Portion against String.

So I need a shorthand to convert them into strings.